### PR TITLE
fix(session): sesión única real (401 en /verificar-sesion, destruir s…

### DIFF
--- a/public/inicio.html
+++ b/public/inicio.html
@@ -252,7 +252,7 @@
       fetch('/verificar-sesion')
         .then(res => {
           if (res.status === 401) {
-            document.getElementById('overlay-sesion').classList.remove('hidden');
+            window.location.href = '/login.html?error=sesion';
           }
         });
     }, 1500);


### PR DESCRIPTION
…esión previa, redirección fiable)## Fix: sesión única por usuario (expulsión inmediata y redirección fiable)

Este PR corrige el comportamiento de “sesión única” cuando el mismo usuario inicia sesión en otro dispositivo.

### Cambios clave
- **Middleware de sesión única**: si la ruta es `/verificar-sesion` y la sesión fue reemplazada, se responde `401` (en lugar de `302`). Para resto de rutas, se mantiene la redirección a `login.html?error=sesion`.
- **/verificar-sesion**: devuelve `401` cuando no hay sesión activa.
- **Login**: se destruye la sesión anterior en el *session store* (`sessionStore.destroy(...)`) para expulsión inmediata del cliente antiguo.
- **Static**: `express.static` se registra después del middleware de sesión para evitar exponer `/inicio.html` sin control. Además se añade un guard opcional para `/inicio.html` (si lo quieres mantener estrictamente protegido).
- **Frontend** (`public/inicio.html`): ante `401` en la verificación periódica, se redirige a `login.html?error=sesion`.

### Comportamiento resultante
1. Usuario A inicia sesión en **dispositivo A**.
2. El mismo usuario inicia sesión en **dispositivo B**.
3. **A** es expulsado en ≤1.5 s (cron de verificación) y redirigido a `login.html?error=sesion`.
4. **B** permanece dentro; la sesión antigua se destruye en el store inmediatamente.

### Cómo probar
```bash
npm install
npm start
# pestaña normal y ventana incognito, iniciar con las mismas credenciales
```

### Notas
- Recomendado en producción: `cookie.secure: true`, `SameSite=strict`, rate-limit en `/login`, y hash de contraseñas (p.ej. `bcrypt`).

---

Si prefieres, puedo dividirlo en commits pequeños (backend / frontend) o dejar solo el fix mínimo sin mover `express.static`.
